### PR TITLE
Update setup.py to install ALL files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Latest release: [![DOI](https://zenodo.org/badge/68331217.svg)](https://zenodo.o
 ```bash
 conda install -c mobleylab smirnoff99frosst=1.0.5
 ```
-(smirnoff99frosst was formerly known as smirnoff99frosst)
+(smirnoff99frosst was formerly known as smirff99frosst)
 
 ## What it is
 

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,17 @@ Setup script to install the smirnoff99Frosst.ffxml as a python package
 
 import sys,os
 from os.path import relpath, join
-
 from setuptools import setup, find_packages
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+def find_package_data(data_root, package_root):
+    files = []
+    for root, dirnames, filenames in os.walk(data_root):
+        for fn in filenames:
+            files.append(relpath(join(root, fn), package_root))
+    return files
 
 if sys.argv[-1] == 'setup.py':
     print("To install, run 'python setup.py install'")
@@ -26,5 +35,6 @@ setup(
     license              = 'MIT',
     platforms            = ['Linux-64', 'Mac OSX-64', 'Unix-64'],
     packages             = find_packages()+['smirnoff99frosst'],
+    package_data = {'smirnoff99frosst':find_package_data('smirnoff99frosst/', 'smirnoff99fross')},
     include_package_data = True
 )


### PR DESCRIPTION
I was running into an issue with MiniDrugBank where the installed directory didn't have anything in it. 

I copied the `find_package_data` from `smarty` and `openforcefield` and now when I do `pip install .` in the smirnoff99Frosst directory it creates a smirnoff99Frosst python package with the ffxml file. 

We would need to do a new conda build/release so that this functionality is addressed in the conda install command to. 

Addresses part of issue #56 