### PR TITLE
Update to include default monovalent ion parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Please see the smarty issue tracker for details.
 - [Version 1.0.5](http://doi.org/10.5281/zenodo.495249): Substantially improved coverage of chemical space via more general generics as well as a variety of new parameters introduced via generalization/estimation from other force fields such as GAFF/GAFF2. This release, this version covers an internal set of molecules from DrugBank filtered to remove metal atoms and to contain only compounds with less than 200 heavy atoms. Full documentation of changes is available [here](https://github.com/open-forcefield-group/smarty/pull/232). 
 
 **Not yet in a version**:
-
+- Add monovalent ion parameters (Joung/Cheatham) for TIP3P as default.
 
 ## Contributors
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,6 @@ setup(
     license              = 'MIT',
     platforms            = ['Linux-64', 'Mac OSX-64', 'Unix-64'],
     packages             = find_packages()+['smirnoff99frosst'],
-    package_data = {'smirnoff99frosst':find_package_data('smirnoff99frosst/', 'smirnoff99fross')},
+    package_data = {'smirnoff99frosst':find_package_data('smirnoff99frosst/', 'smirnoff99frosst')},
     include_package_data = True
 )

--- a/smirnoff99Frosst/smirnoff99Frosst.ffxml
+++ b/smirnoff99Frosst/smirnoff99Frosst.ffxml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='ASCII'?>
 <SMIRNOFF version="0.1" aromaticity_model="OEAroModel_MDL">
   <!-- SMIRNOFF (SMIRKS Native Open Force Field) template file -->
-  <Date>Date: May 25, 2017</Date>
+  <Date>Date: Aug. 3, 2017</Date>
   <Author>C. I. Bayly, OpenEye/UC Irvine; C. C. Bannan, UC Irvine; D. L. Mobley, UC Irvine</Author>
   <!-- This file is meant for processing via openforcefield.typing.engines.smirnoff -->
   <!-- WARNING: AMBER functional forms drop the factor of 2 in the bond energy term, so cross-comparing this file with a corresponding .frcmod file, it will appear that the values here are twice as large as they should be. -->
@@ -141,75 +141,75 @@
     <Improper smirks="[*:1]~[#6X3:2](=[#7X2,#7X3+1:3])~[#7:4]" id="i4" k1="10.5" periodicity1="2" phase1="180."/>
     <Proper smirks="[*:1]~[*:2]~[*:3]~[*:4]" id="t1" idivf1="4" k1="3.50" periodicity1="2" phase1="180.0"/>
     <Proper smirks="[*:1]-[#6X4:2]-[#6X4:3]-[*:4]" id="t2" idivf1="1" k1="0.156" periodicity1="3" phase1="0.0"/>
-    <Proper smirks="[#6X4:1]-[#6X4:2]-[#6X4:3]-[#6X4:4]" id="t3" idivf1="1" k1="0.180" periodicity1="3" phase1="0.0" k2="0.250" phase2="180.0" idivf2="1" periodicity2="2" phase3="180.0" idivf3="1" k3="0.200" periodicity3="1"/>
+    <Proper smirks="[#6X4:1]-[#6X4:2]-[#6X4:3]-[#6X4:4]" id="t3" idivf1="1" k1="0.180" periodicity1="3" phase1="0.0" k2="0.250" idivf2="1" periodicity2="2" phase2="180.0" phase3="180.0" k3="0.200" idivf3="1" periodicity3="1"/>
     <Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#1:4]" id="t4" idivf1="1" k1="0.150" periodicity1="3" phase1="0.0"/>
     <Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#6X4:4]" id="t5" idivf1="1" k1="0.160" periodicity1="3" phase1="0.0"/>
-    <Proper smirks="[#8X2:1]-[#6X4:2]-[#6X4:3]-[#8X2:4]" id="t6" idivf1="1" k1="0.144" periodicity1="3" phase1="0.0" k2="1.175" phase2="0.0" idivf2="1" periodicity2="2"/>
-    <Proper smirks="[#9:1]-[#6X4:2]-[#6X4:3]-[#9:4]" id="t7" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0" k2="1.200" phase2="180.0" idivf2="1" periodicity2="1"/>
-    <Proper smirks="[#17:1]-[#6X4:2]-[#6X4:3]-[#17:4]" id="t8" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0" k2="0.450" phase2="180.0" idivf2="1" periodicity2="1"/>
-    <Proper smirks="[#35:1]-[#6X4:2]-[#6X4:3]-[#35:4]" id="t9" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0" k2="0.000" phase2="180.0" idivf2="1" periodicity2="1"/>
-    <Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#8X2:4]" id="t10" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0" k2="0.250" phase2="0.0" idivf2="1" periodicity2="1"/>
-    <Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#9:4]" id="t11" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0" k2="0.190" phase2="0.0" idivf2="1" periodicity2="1"/>
-    <Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#17:4]" id="t12" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0" k2="0.250" phase2="0.0" idivf2="1" periodicity2="1"/>
-    <Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#35:4]" id="t13" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0" k2="0.550" phase2="0.0" idivf2="1" periodicity2="1"/>
+    <Proper smirks="[#8X2:1]-[#6X4:2]-[#6X4:3]-[#8X2:4]" id="t6" idivf1="1" k1="0.144" periodicity1="3" phase1="0.0" k2="1.175" idivf2="1" periodicity2="2" phase2="0.0"/>
+    <Proper smirks="[#9:1]-[#6X4:2]-[#6X4:3]-[#9:4]" id="t7" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0" k2="1.200" idivf2="1" periodicity2="1" phase2="180.0"/>
+    <Proper smirks="[#17:1]-[#6X4:2]-[#6X4:3]-[#17:4]" id="t8" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0" k2="0.450" idivf2="1" periodicity2="1" phase2="180.0"/>
+    <Proper smirks="[#35:1]-[#6X4:2]-[#6X4:3]-[#35:4]" id="t9" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0" k2="0.000" idivf2="1" periodicity2="1" phase2="180.0"/>
+    <Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#8X2:4]" id="t10" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0" k2="0.250" idivf2="1" periodicity2="1" phase2="0.0"/>
+    <Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#9:4]" id="t11" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0" k2="0.190" idivf2="1" periodicity2="1" phase2="0.0"/>
+    <Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#17:4]" id="t12" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0" k2="0.250" idivf2="1" periodicity2="1" phase2="0.0"/>
+    <Proper smirks="[#1:1]-[#6X4:2]-[#6X4:3]-[#35:4]" id="t13" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0" k2="0.550" idivf2="1" periodicity2="1" phase2="0.0"/>
     <Proper smirks="[*:1]-[#6X4:2]-[#6X4;r3:3]-[*:4]" id="t14" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[*:1]-[#6X4:2]-[#6X4;r3:3]-[#6X4;r3:4]" id="t15" idivf1="1" k1="1.0" periodicity1="3" phase1="0.0"/>
     <Proper smirks="[*:1]-[#6X4;r3:2]-@[#6X4;r3:3]-[*:4]" id="t16" idivf1="1" k1="0.000" periodicity1="2" phase1="0.0"/>
-    <Proper smirks="[#6X4;r3:1]-[#6X4;r3:2]-[#6X4;r3:3]-[*:4]" id="t17" idivf1="1" k1="3.000" periodicity1="2" phase1="0.0" k2="2.700" phase2="0.0" idivf2="1" periodicity2="1"/>
+    <Proper smirks="[#6X4;r3:1]-[#6X4;r3:2]-[#6X4;r3:3]-[*:4]" id="t17" idivf1="1" k1="3.000" periodicity1="2" phase1="0.0" k2="2.700" idivf2="1" periodicity2="1" phase2="0.0"/>
     <Proper smirks="[*:1]~[#6X3:2]-[#6X4:3]-[*:4]" id="t18" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0"/>
-    <Proper smirks="[#1:1]-[#6X4:2]-[#6X3:3]=[#8X1:4]" id="t19" idivf1="1" k1="0.800" periodicity1="1" phase1="0.0" k2="0.000" phase2="0.0" idivf2="1" periodicity2="2" phase3="180.0" idivf3="1" k3="0.080" periodicity3="3"/>
-    <Proper smirks="[#1:1]-[#6X4:2]-[#6X3:3]=[#6X3:4]" id="t20" idivf1="1" k1="0.380" periodicity1="3" phase1="180.0" k2="1.150" phase2="0.0" idivf2="1" periodicity2="1" phase3="180.0" idivf3="1" k3="1.000" periodicity3="3"/>
+    <Proper smirks="[#1:1]-[#6X4:2]-[#6X3:3]=[#8X1:4]" id="t19" idivf1="1" k1="0.800" periodicity1="1" phase1="0.0" k2="0.000" idivf2="1" periodicity2="2" phase2="0.0" phase3="180.0" k3="0.080" idivf3="1" periodicity3="3"/>
+    <Proper smirks="[#1:1]-[#6X4:2]-[#6X3:3]=[#6X3:4]" id="t20" idivf1="1" k1="0.380" periodicity1="3" phase1="180.0" k2="1.150" idivf2="1" periodicity2="1" phase2="0.0" phase3="180.0" k3="1.000" idivf3="1" periodicity3="3"/>
     <Proper smirks="[*:1]-[#6X4:2]-[#6X3:3]=[*:4]" id="t21" idivf1="1" k1="0.000" periodicity1="2" phase1="0.0"/>
-    <Proper smirks="[#6X3:1]-[#6X4:2]-[#6X3:3]=[#6X3:4]" id="t22" idivf1="1" k1="0.450" periodicity1="3" phase1="0.0" k2="0.250" phase2="180.0" idivf2="1" periodicity2="2"/>
-    <Proper smirks="[#7X3:1]-[#6X4:2]-[#6X3:3]-[#7X3:4]" id="t23" idivf1="1" k1="1.700" periodicity1="1" phase1="180.0" k2="2.000" phase2="180.0" idivf2="1" periodicity2="2"/>
-    <Proper smirks="[#6X4:1]-[#6X4:2]-[#6X3:3]-[#7X3:4]" id="t24" idivf1="1" k1="0.100" periodicity1="4" phase1="0.0" k2="0.070" phase2="0.0" idivf2="1" periodicity2="2"/>
-    <Proper smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X3:2]-[#6X4:3]-[#1:4]" id="t25" idivf1="1" k1="0.260" periodicity1="2" phase1="0.0" k2="0.350" phase2="180.0" idivf2="1" periodicity2="1"/>
-    <Proper smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X3:2]-[#6X4:3]-[#7X4,#7X3:4]" id="t26" idivf1="1" k1="0.988" periodicity1="4" phase1="0.0" k2="0.258" phase2="0.0" idivf2="1" periodicity2="3" phase3="0.0" idivf3="1" k3="0.805" periodicity3="2" periodicity4="2" k4="2.059" phase4="270.0" idivf4="1" periodicity5="1" idivf5="1" k5="1.710" phase5="90.0"/>
-    <Proper smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X3:2]-[#6X4:3]-[#7X3$(*-[#6X3,#6X2]):4]" id="t27" idivf1="1" k1="0.285" periodicity1="4" phase1="270.0" k2="0.669" phase2="0.0" idivf2="1" periodicity2="3" phase3="180.0" idivf3="1" k3="0.310" periodicity3="2" periodicity4="2" k4="0.548" phase4="270.0" idivf4="1" periodicity5="1" idivf5="1" k5="0.263" phase5="270.0" idivf6="1" k6="0.222" periodicity6="1" phase6="0.0"/>
+    <Proper smirks="[#6X3:1]-[#6X4:2]-[#6X3:3]=[#6X3:4]" id="t22" idivf1="1" k1="0.450" periodicity1="3" phase1="0.0" k2="0.250" idivf2="1" periodicity2="2" phase2="180.0"/>
+    <Proper smirks="[#7X3:1]-[#6X4:2]-[#6X3:3]-[#7X3:4]" id="t23" idivf1="1" k1="1.700" periodicity1="1" phase1="180.0" k2="2.000" idivf2="1" periodicity2="2" phase2="180.0"/>
+    <Proper smirks="[#6X4:1]-[#6X4:2]-[#6X3:3]-[#7X3:4]" id="t24" idivf1="1" k1="0.100" periodicity1="4" phase1="0.0" k2="0.070" idivf2="1" periodicity2="2" phase2="0.0"/>
+    <Proper smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X3:2]-[#6X4:3]-[#1:4]" id="t25" idivf1="1" k1="0.260" periodicity1="2" phase1="0.0" k2="0.350" idivf2="1" periodicity2="1" phase2="180.0"/>
+    <Proper smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X3:2]-[#6X4:3]-[#7X4,#7X3:4]" id="t26" idivf1="1" k1="0.988" periodicity1="4" phase1="0.0" k2="0.258" idivf2="1" periodicity2="3" phase2="0.0" phase3="0.0" k3="0.805" idivf3="1" periodicity3="2" idivf4="1" phase4="270.0" periodicity4="2" k4="2.059" periodicity5="1" idivf5="1" phase5="90.0" k5="1.710"/>
+    <Proper smirks="[#16X2,#16X1-1,#16X3+1:1]-[#6X3:2]-[#6X4:3]-[#7X3$(*-[#6X3,#6X2]):4]" id="t27" idivf1="1" k1="0.285" periodicity1="4" phase1="270.0" k2="0.669" idivf2="1" periodicity2="3" phase2="0.0" phase3="180.0" k3="0.310" idivf3="1" periodicity3="2" idivf4="1" phase4="270.0" periodicity4="2" k4="0.548" periodicity5="1" idivf5="1" phase5="270.0" k5="0.263" phase6="0.0" idivf6="1" periodicity6="1" k6="0.222"/>
     <Proper smirks="[*:1]-[#6X4;r3:2]-[#6X3:3]~[*:4]" id="t28" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
-    <Proper smirks="[#6X4:1]-[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" id="t29" idivf1="1" k1="0.065" periodicity1="4" phase1="180.0" k2="0.550" phase2="180.0" idivf2="1" periodicity2="2"/>
-    <Proper smirks="[#1:1]-[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" id="t30" idivf1="1" k1="0.050" periodicity1="4" phase1="180.0" k2="0.150" phase2="0.0" idivf2="1" periodicity2="3" phase3="180.0" idivf3="1" k3="0.150" periodicity3="2"/>
-    <Proper smirks="[#6X3:1]-[#6X4;r3:2]-[#6X3:3]-[#7X3:4]" id="t31" idivf1="1" k1="1.392" periodicity1="2" phase1="0.0" k2="0.645" phase2="180.0" idivf2="1" periodicity2="1" phase3="180.0" idivf3="1" k3="0.961" periodicity3="3"/>
-    <Proper smirks="[#6X3:1]-[#6X4;r3:2]-[#6X3:3]=[#8X1:4]" id="t32" idivf1="1" k1="3.174" periodicity1="2" phase1="180.0" k2="0.277" phase2="180.0" idivf2="1" periodicity2="1" phase3="180.0" idivf3="1" k3="0.514" periodicity3="3"/>
+    <Proper smirks="[#6X4:1]-[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" id="t29" idivf1="1" k1="0.065" periodicity1="4" phase1="180.0" k2="0.550" idivf2="1" periodicity2="2" phase2="180.0"/>
+    <Proper smirks="[#1:1]-[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" id="t30" idivf1="1" k1="0.050" periodicity1="4" phase1="180.0" k2="0.150" idivf2="1" periodicity2="3" phase2="0.0" phase3="180.0" k3="0.150" idivf3="1" periodicity3="2"/>
+    <Proper smirks="[#6X3:1]-[#6X4;r3:2]-[#6X3:3]-[#7X3:4]" id="t31" idivf1="1" k1="1.392" periodicity1="2" phase1="0.0" k2="0.645" idivf2="1" periodicity2="1" phase2="180.0" phase3="180.0" k3="0.961" idivf3="1" periodicity3="3"/>
+    <Proper smirks="[#6X3:1]-[#6X4;r3:2]-[#6X3:3]=[#8X1:4]" id="t32" idivf1="1" k1="3.174" periodicity1="2" phase1="180.0" k2="0.277" idivf2="1" periodicity2="1" phase2="180.0" phase3="180.0" k3="0.514" idivf3="1" periodicity3="3"/>
     <Proper smirks="[#6X3:1]-[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" id="t33" idivf1="1" k1="0.128" periodicity1="2" phase1="180.0"/>
-    <Proper smirks="[#7X3:1]-[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" id="t34" idivf1="1" k1="0.065" periodicity1="4" phase1="180.0" k2="0.550" phase2="180.0" idivf2="1" periodicity2="2"/>
-    <Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" id="t35" idivf1="1" k1="0.050" periodicity1="4" phase1="180.0" k2="0.250" phase2="0.0" idivf2="1" periodicity2="3" phase3="180.0" idivf3="1" k3="0.010" periodicity3="2"/>
-    <Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3;r6:3]:[#6X3;r6:4]" id="t36" idivf1="1" k1="0.065" periodicity1="4" phase1="180.0" k2="0.550" phase2="180.0" idivf2="1" periodicity2="2"/>
-    <Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3;r5:3]-;@[#6X3;r5:4]" id="t37" idivf1="1" k1="0.050" periodicity1="4" phase1="180.0" k2="0.250" phase2="0.0" idivf2="1" periodicity2="3" phase3="180.0" idivf3="1" k3="0.010" periodicity3="2"/>
+    <Proper smirks="[#7X3:1]-[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" id="t34" idivf1="1" k1="0.065" periodicity1="4" phase1="180.0" k2="0.550" idivf2="1" periodicity2="2" phase2="180.0"/>
+    <Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]~[#6X3:4]" id="t35" idivf1="1" k1="0.050" periodicity1="4" phase1="180.0" k2="0.250" idivf2="1" periodicity2="3" phase2="0.0" phase3="180.0" k3="0.010" idivf3="1" periodicity3="2"/>
+    <Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3;r6:3]:[#6X3;r6:4]" id="t36" idivf1="1" k1="0.065" periodicity1="4" phase1="180.0" k2="0.550" idivf2="1" periodicity2="2" phase2="180.0"/>
+    <Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3;r5:3]-;@[#6X3;r5:4]" id="t37" idivf1="1" k1="0.050" periodicity1="4" phase1="180.0" k2="0.250" idivf2="1" periodicity2="3" phase2="0.0" phase3="180.0" k3="0.010" idivf3="1" periodicity3="2"/>
     <Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3;r5:3]=;@[#6X3;r5:4]" id="t38" idivf1="1" k1="0.300" periodicity1="1" phase1="180.0"/>
     <Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]-[#6X4:4]" id="t39" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
-    <Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3;r6:3]:[#7X2;r6:4]" id="t40" idivf1="1" k1="2.100" periodicity1="2" phase1="180.0" k2="0.432" phase2="180.0" idivf2="1" periodicity2="1" phase3="0.0" idivf3="1" k3="0.620" periodicity3="3"/>
-    <Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]=[#7X2:4]" id="t41" idivf1="1" k1="0.300" periodicity1="3" phase1="0.0" k2="0.950" phase2="180.0" idivf2="1" periodicity2="2" phase3="180.0" idivf3="1" k3="0.275" periodicity3="1"/>
-    <Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]-[#8X2:4]" id="t42" idivf1="1" k1="0.065" periodicity1="4" phase1="180.0" k2="0.550" phase2="180.0" idivf2="1" periodicity2="2"/>
+    <Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3;r6:3]:[#7X2;r6:4]" id="t40" idivf1="1" k1="2.100" periodicity1="2" phase1="180.0" k2="0.432" idivf2="1" periodicity2="1" phase2="180.0" phase3="0.0" k3="0.620" idivf3="1" periodicity3="3"/>
+    <Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]=[#7X2:4]" id="t41" idivf1="1" k1="0.300" periodicity1="3" phase1="0.0" k2="0.950" idivf2="1" periodicity2="2" phase2="180.0" phase3="180.0" k3="0.275" idivf3="1" periodicity3="1"/>
+    <Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]-[#8X2:4]" id="t42" idivf1="1" k1="0.065" periodicity1="4" phase1="180.0" k2="0.550" idivf2="1" periodicity2="2" phase2="180.0"/>
     <Proper smirks="[#6X4;r3:1]-;@[#6X4;r3:2]-[#6X3:3]=[#8X1:4]" id="t43" idivf1="1" k1="2.400" periodicity1="2" phase1="320.0"/>
     <Proper smirks="[*:1]~[#6X3:2]-[#6X3:3]~[*:4]" id="t44" idivf1="1" k1="0.625" periodicity1="2" phase1="180.0"/>
     <Proper smirks="[*:1]~[#6X3:2]:[#6X3:3]~[*:4]" id="t45" idivf1="1" k1="3.625" periodicity1="2" phase1="180.0"/>
     <Proper smirks="[*:1]-,:[#6X3:2]=[#6X3:3]-,:[*:4]" id="t46" idivf1="1" k1="5.4" periodicity1="2" phase1="180.0"/>
-    <Proper smirks="[#6X4:1]-[#6X3:2]=[#6X3:3]-[#6X4:4]" id="t47" idivf1="1" k1="6.650" periodicity1="2" phase1="180.0" k2="1.900" phase2="180.0" idivf2="1" periodicity2="1"/>
+    <Proper smirks="[#6X4:1]-[#6X3:2]=[#6X3:3]-[#6X4:4]" id="t47" idivf1="1" k1="6.650" periodicity1="2" phase1="180.0" k2="1.900" idivf2="1" periodicity2="1" phase2="180.0"/>
     <Proper smirks="[*:1]~[#6X3:2]-[#6X3$(*=[#8,#16,#7]):3]~[*:4]" id="t48" idivf1="1" k1="0.250" periodicity1="2" phase1="180.0"/>
-    <Proper smirks="[#6X3:1]=[#6X3:2]-[#6X3:3]=[#8X1:4]" id="t49" idivf1="1" k1="2.175" periodicity1="2" phase1="180.0" k2="0.300" phase2="0.0" idivf2="1" periodicity2="3"/>
+    <Proper smirks="[#6X3:1]=[#6X3:2]-[#6X3:3]=[#8X1:4]" id="t49" idivf1="1" k1="2.175" periodicity1="2" phase1="180.0" k2="0.300" idivf2="1" periodicity2="3" phase2="0.0"/>
     <Proper smirks="[*:1]~[#7a:2]:[#6a:3]~[*:4]" id="t50" idivf1="1" k1="4.80" periodicity1="2" phase1="180."/>
     <Proper smirks="[*:1]-[#6X4:2]-[#7X4:3]-[*:4]" id="t51" idivf1="1" k1="0.156" periodicity1="3" phase1="0.0"/>
     <Proper smirks="[*:1]-[#6X4:2]-[#7X3:3]-[*:4]" id="t52" idivf1="1" k1="0.300" periodicity1="3" phase1="0.0"/>
-    <Proper smirks="[#6X4:1]-[#6X4:2]-[#7X4,#7X3:3]-[#6X4:4]" id="t53" idivf1="1" k1="0.300" periodicity1="3" phase1="0.0" k2="0.480" phase2="180.0" idivf2="1" periodicity2="2"/>
+    <Proper smirks="[#6X4:1]-[#6X4:2]-[#7X4,#7X3:3]-[#6X4:4]" id="t53" idivf1="1" k1="0.300" periodicity1="3" phase1="0.0" k2="0.480" idivf2="1" periodicity2="2" phase2="180.0"/>
     <Proper smirks="[*:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]" id="t54" idivf1="1" k1="1.000" periodicity1="3" phase1="0.0"/>
     <Proper smirks="[#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]" id="t55" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]" id="t56" idivf1="1" k1="2.700" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[!1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[*:4]" id="t57" idivf1="1" k1="0.156" periodicity1="3" phase1="0.0"/>
     <Proper smirks="[!#1:1]-[#7X4,#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]" id="t58" idivf1="1" k1="1.000" periodicity1="3" phase1="0.0"/>
     <Proper smirks="[*:1]-[#7X4:2]-[#6X3:3]~[*:4]" id="t59" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
-    <Proper smirks="[*:1]-[#6X4:2]-[#7X3$(*~[#6X3,#6X2]):3]~[*:4]" id="t60" idivf1="1" k1="0.000" periodicity1="2" phase1="0.0" k2="0.000" phase2="0.0" idivf2="1" periodicity2="3"/>
+    <Proper smirks="[*:1]-[#6X4:2]-[#7X3$(*~[#6X3,#6X2]):3]~[*:4]" id="t60" idivf1="1" k1="0.000" periodicity1="2" phase1="0.0" k2="0.000" idivf2="1" periodicity2="3" phase2="0.0"/>
     <Proper smirks="[*:1]-[#6X4:2]-[#7X3$(*~[#8X1]):3]~[#8X1:4]" id="t61" idivf1="1" k1="0.000" periodicity1="3" phase1="0.0"/>
-    <Proper smirks="[#6X3:1]-[#7X3:2]-[#6X4:3]-[#6X3:4]" id="t62" idivf1="1" k1="0.850" periodicity1="2" phase1="180.0" k2="0.800" phase2="0.0" idivf2="1" periodicity2="1"/>
-    <Proper smirks="[#6X4:1]-[#6X4:2]-[#7X3:3]-[#6X3:4]=[#8,#16,#7]" id="t63" idivf1="1" k1="0.500" periodicity1="4" phase1="180.0" k2="0.150" phase2="180.0" idivf2="1" periodicity2="3" phase3="0.0" idivf3="1" k3="0.000" periodicity3="2" periodicity4="1" k4="0.530" phase4="0.0" idivf4="1"/>
-    <Proper smirks="[#8X2H0:1]-[#6X4:2]-[#7X3:3]-[#6X3:4]" id="t64" idivf1="1" k1="0.000" periodicity1="2" phase1="0.0" k2="2.500" phase2="0.0" idivf2="1" periodicity2="1"/>
-    <Proper smirks="[#6X3:1]-[#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]" id="t65" idivf1="1" k1="0.500" periodicity1="3" phase1="0.0" k2="1.750" phase2="0.0" idivf2="1" periodicity2="2" phase3="0.0" idivf3="1" k3="0.250" periodicity3="1"/>
+    <Proper smirks="[#6X3:1]-[#7X3:2]-[#6X4:3]-[#6X3:4]" id="t62" idivf1="1" k1="0.850" periodicity1="2" phase1="180.0" k2="0.800" idivf2="1" periodicity2="1" phase2="0.0"/>
+    <Proper smirks="[#6X4:1]-[#6X4:2]-[#7X3:3]-[#6X3:4]=[#8,#16,#7]" id="t63" idivf1="1" k1="0.500" periodicity1="4" phase1="180.0" k2="0.150" idivf2="1" periodicity2="3" phase2="180.0" phase3="0.0" k3="0.000" idivf3="1" periodicity3="2" idivf4="1" phase4="0.0" periodicity4="1" k4="0.530"/>
+    <Proper smirks="[#8X2H0:1]-[#6X4:2]-[#7X3:3]-[#6X3:4]" id="t64" idivf1="1" k1="0.000" periodicity1="2" phase1="0.0" k2="2.500" idivf2="1" periodicity2="1" phase2="0.0"/>
+    <Proper smirks="[#6X3:1]-[#7X3:2]-[#6X4;r3:3]-[#6X4;r3:4]" id="t65" idivf1="1" k1="0.500" periodicity1="3" phase1="0.0" k2="1.750" idivf2="1" periodicity2="2" phase2="0.0" phase3="0.0" k3="0.250" idivf3="1" periodicity3="1"/>
     <Proper smirks="[*:1]~[#7X2:2]-[#6X4:3]-[*:4]" id="t66" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[#6X3:1]=[#7X2,#7X3+1:2]-[#6X4:3]-[#1:4]" id="t67" idivf1="1" k1="0.500" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[#6X3:1]=[#7X2,#7X3+1:2]-[#6X4:3]-[#6X3,#6X4:4]" id="t68" idivf1="1" k1="1.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[*:1]~[#7X3,#7X2-1:2]-[#6X3:3]~[*:4]" id="t69" idivf1="1" k1="1." periodicity1="2" phase1="180.0"/>
     <Proper smirks="[*:1]~[#7X3,#7X2-1:2]-!@[#6X3:3]~[*:4]" id="t70" idivf1="1" k1="0.625" periodicity1="2" phase1="180.0"/>
-    <Proper smirks="[#1:1]-[#7X3:2]-[#6X3:3]=[#8,#16,#7:4]" id="t71" idivf1="1" k1="2.500" periodicity1="2" phase1="180.0" k2="2.000" phase2="0.0" idivf2="1" periodicity2="1"/>
+    <Proper smirks="[#1:1]-[#7X3:2]-[#6X3:3]=[#8,#16,#7:4]" id="t71" idivf1="1" k1="2.500" periodicity1="2" phase1="180.0" k2="2.000" idivf2="1" periodicity2="1" phase2="0.0"/>
     <Proper smirks="[*:1]-[#7X3;r5:2]-@[#6X3;r5:3]~[*:4]" id="t72" idivf1="1" k1="1.40" periodicity1="2" phase1="180.0"/>
     <Proper smirks="[#8X1:1]~[#7X3:2]~[#6X3:3]~[*:4]" id="t73" idivf1="1" k1="3.600" periodicity1="2" phase1="180.0"/>
     <Proper smirks="[*:1]=[#7X2,#7X3+1:2]-[#6X3:3]-[*:4]" id="t74" idivf1="1" k1="0.0" periodicity1="2" phase1="180.0"/>
@@ -224,23 +224,23 @@
     <Proper smirks="[#7X1:1]~[#7X2:2]-[#6X4:3]-[#6X3:4]" id="t83" idivf1="1" k1="0.000" periodicity1="2" phase1="0.0"/>
     <Proper smirks="[#7X1:1]~[#7X2:2]-[#6X4:3]~[#1:4]" id="t84" idivf1="1" k1="0.000" periodicity1="2" phase1="0.0"/>
     <Proper smirks="[*:1]-[#6X4:2]-[#8X2:3]-[#1:4]" id="t85" idivf1="3" k1="0.500" periodicity1="3" phase1="0.0"/>
-    <Proper smirks="[#6X4:1]-[#6X4:2]-[#8X2H1:3]-[#1:4]" id="t86" idivf1="1" k1="0.160" periodicity1="3" phase1="0.0" k2="0.250" phase2="0.0" idivf2="1" periodicity2="1"/>
+    <Proper smirks="[#6X4:1]-[#6X4:2]-[#8X2H1:3]-[#1:4]" id="t86" idivf1="1" k1="0.160" periodicity1="3" phase1="0.0" k2="0.250" idivf2="1" periodicity2="1" phase2="0.0"/>
     <Proper smirks="[*:1]-[#6X4:2]-[#8X2H0:3]-[*:4]" id="t87" idivf1="3" k1="1.15" periodicity1="3" phase1="0.0"/>
-    <Proper smirks="[#6X4:1]-[#6X4:2]-[#8X2H0:3]-[#6X4:4]" id="t88" idivf1="1" k1="0.383" periodicity1="3" phase1="0.0" k2="0.100" phase2="180.0" idivf2="1" periodicity2="2"/>
-    <Proper smirks="[#6X4:1]-[#6X4:2]-[#8X2:3]-[#6X3:4]" id="t89" idivf1="1" k1="0.383" periodicity1="3" phase1="0.0" k2="0.800" phase2="180.0" idivf2="1" periodicity2="1"/>
-    <Proper smirks="[#6X4:1]-[#8X2:2]-[#6X4:3]-[#8X2:4]" id="t90" idivf1="1" k1="0.100" periodicity1="3" phase1="0.0" k2="0.850" phase2="180.0" idivf2="1" periodicity2="2" phase3="180.0" idivf3="1" k3="1.350" periodicity3="1"/>
-    <Proper smirks="[#6X4:1]-[#8X2:2]-[#6X4:3]-[#7X3:4]" id="t91" idivf1="1" k1="0.383" periodicity1="3" phase1="0.0" k2="0.650" phase2="0.0" idivf2="1" periodicity2="2"/>
+    <Proper smirks="[#6X4:1]-[#6X4:2]-[#8X2H0:3]-[#6X4:4]" id="t88" idivf1="1" k1="0.383" periodicity1="3" phase1="0.0" k2="0.100" idivf2="1" periodicity2="2" phase2="180.0"/>
+    <Proper smirks="[#6X4:1]-[#6X4:2]-[#8X2:3]-[#6X3:4]" id="t89" idivf1="1" k1="0.383" periodicity1="3" phase1="0.0" k2="0.800" idivf2="1" periodicity2="1" phase2="180.0"/>
+    <Proper smirks="[#6X4:1]-[#8X2:2]-[#6X4:3]-[#8X2:4]" id="t90" idivf1="1" k1="0.100" periodicity1="3" phase1="0.0" k2="0.850" idivf2="1" periodicity2="2" phase2="180.0" phase3="180.0" k3="1.350" idivf3="1" periodicity3="1"/>
+    <Proper smirks="[#6X4:1]-[#8X2:2]-[#6X4:3]-[#7X3:4]" id="t91" idivf1="1" k1="0.383" periodicity1="3" phase1="0.0" k2="0.650" idivf2="1" periodicity2="2" phase2="0.0"/>
     <Proper smirks="[#6X3:1]-[#8X2:2]-[#6X4;r3:3]-@[#6X4;r3:4]" id="t92" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[#6X3:1]-[#8X2:2]-[#6X4;r3:3]-[#1:4]" id="t93" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
-    <Proper smirks="[#1:1]-[#8X2:2]-[#6X4;r3:3]-[#1:4]" id="t94" idivf1="1" k1="0.400" periodicity1="3" phase1="0.0" k2="0.500" phase2="0.0" idivf2="1" periodicity2="2" phase3="0.0" idivf3="1" k3="0.700" periodicity3="1"/>
-    <Proper smirks="[#1:1]-[#8X2:2]-[#6X4;r3:3]-[#6X4:4]" id="t95" idivf1="1" k1="0.400" periodicity1="3" phase1="0.0" k2="0.500" phase2="0.0" idivf2="1" periodicity2="2" phase3="0.0" idivf3="1" k3="0.700" periodicity3="1"/>
-    <Proper smirks="[#1:1]-[#8X2:2]-[#6X4;r3:3]-[#6X4;r3:4]" id="t96" idivf1="1" k1="0.400" periodicity1="3" phase1="0.0" k2="0.500" phase2="0.0" idivf2="1" periodicity2="2" phase3="0.0" idivf3="1" k3="0.700" periodicity3="1"/>
+    <Proper smirks="[#1:1]-[#8X2:2]-[#6X4;r3:3]-[#1:4]" id="t94" idivf1="1" k1="0.400" periodicity1="3" phase1="0.0" k2="0.500" idivf2="1" periodicity2="2" phase2="0.0" phase3="0.0" k3="0.700" idivf3="1" periodicity3="1"/>
+    <Proper smirks="[#1:1]-[#8X2:2]-[#6X4;r3:3]-[#6X4:4]" id="t95" idivf1="1" k1="0.400" periodicity1="3" phase1="0.0" k2="0.500" idivf2="1" periodicity2="2" phase2="0.0" phase3="0.0" k3="0.700" idivf3="1" periodicity3="1"/>
+    <Proper smirks="[#1:1]-[#8X2:2]-[#6X4;r3:3]-[#6X4;r3:4]" id="t96" idivf1="1" k1="0.400" periodicity1="3" phase1="0.0" k2="0.500" idivf2="1" periodicity2="2" phase2="0.0" phase3="0.0" k3="0.700" idivf3="1" periodicity3="1"/>
     <Proper smirks="[*:1]~[#6X3:2]-[#8X2:3]-[*:4]" id="t97" idivf1="1" k1="1.050" periodicity1="2" phase1="180.0"/>
     <Proper smirks="[*:1]~[#6X3:2]-[#8X2:3]-[#1:4]" id="t98" idivf1="1" k1="0.900" periodicity1="2" phase1="180.0"/>
     <Proper smirks="[*:1]~[#6X3:2](=[#8,#16,#7])-[#8X2H0:3]-[*:4]" id="t99" idivf1="1" k1="2.700" periodicity1="2" phase1="180.0"/>
     <Proper smirks="[*:1]~[#6X3:2](=[#8,#16,#7])-[#8:3]-[#1:4]" id="t100" idivf1="1" k1="2.300" periodicity1="2" phase1="180.0"/>
-    <Proper smirks="[#1:1]-[#8X2:2]-[#6X3:3]=[#8X1:4]" id="t101" idivf1="1" k1="2.300" periodicity1="2" phase1="180.0" k2="1.900" phase2="0.0" idivf2="1" periodicity2="1"/>
-    <Proper smirks="[#8,#16,#7:1]=[#6X3:2]-[#8X2H0:3]-[#6X4:4]" id="t102" idivf1="1" k1="2.700" periodicity1="2" phase1="180.0" k2="1.400" phase2="180.0" idivf2="1" periodicity2="1"/>
+    <Proper smirks="[#1:1]-[#8X2:2]-[#6X3:3]=[#8X1:4]" id="t101" idivf1="1" k1="2.300" periodicity1="2" phase1="180.0" k2="1.900" idivf2="1" periodicity2="1" phase2="0.0"/>
+    <Proper smirks="[#8,#16,#7:1]=[#6X3:2]-[#8X2H0:3]-[#6X4:4]" id="t102" idivf1="1" k1="2.700" periodicity1="2" phase1="180.0" k2="1.400" idivf2="1" periodicity2="1" phase2="180.0"/>
     <Proper smirks="[#1:1]-[#8X2H1:2]-@[#6X3:3]~[*:4]" id="t103" idivf1="1" k1="2.500" periodicity1="2" phase1="180.0"/>
     <Proper smirks="[*:1]-[#8X2+1:2]=[#6X3:3]-[*:4]" id="t104" idivf1="1" k1="3." periodicity1="2" phase1="180.0"/>
     <Proper smirks="[*:1]=[#8X2+1:2]-[#6:3]~[*:4]" id="t105" idivf1="1" k1="0.5" periodicity1="2" phase1="180.0"/>
@@ -261,9 +261,9 @@
     <Proper smirks="[*:1]-[#8X2r5:2]-;@[#7X3r5:3]~[*:4]" id="t120" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[*:1]-[#8X2r5:2]-;@[#7X2r5:3]~[*:4]" id="t121" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[*:1]-[#7X4,#7X3:2]-[#7X4,#7X3:3]-[*:4]" id="t122" idivf1="1" k1="0." periodicity1="3" phase1="0.0"/>
-    <Proper smirks="[#1:1]-[#7X4,#7X3:2]-[#7X4,#7X3:3]-[#1:4]" id="t123" idivf1="1" k1="0.125" periodicity1="3" phase1="0.0" k2="1.875" phase2="0.0" idivf2="1" periodicity2="2" phase3="0.0" idivf3="1" k3="0.750" periodicity3="1"/>
-    <Proper smirks="[#6X4:1]-[#7X4,#7X3:2]-[#7X4,#7X3:3]-[#1:4]" id="t124" idivf1="1" k1="0.400" periodicity1="3" phase1="0.0" k2="2.150" phase2="0.0" idivf2="1" periodicity2="2" phase3="0.0" idivf3="1" k3="1.200" periodicity3="1"/>
-    <Proper smirks="[#6X4:1]-[#7X4,#7X3:2]-[#7X4,#7X3:3]-[#6X4:4]" id="t125" idivf1="1" k1="0.375" periodicity1="3" phase1="0.0" k2="2.125" phase2="0.0" idivf2="1" periodicity2="2" phase3="0.0" idivf3="1" k3="1.500" periodicity3="1"/>
+    <Proper smirks="[#1:1]-[#7X4,#7X3:2]-[#7X4,#7X3:3]-[#1:4]" id="t123" idivf1="1" k1="0.125" periodicity1="3" phase1="0.0" k2="1.875" idivf2="1" periodicity2="2" phase2="0.0" phase3="0.0" k3="0.750" idivf3="1" periodicity3="1"/>
+    <Proper smirks="[#6X4:1]-[#7X4,#7X3:2]-[#7X4,#7X3:3]-[#1:4]" id="t124" idivf1="1" k1="0.400" periodicity1="3" phase1="0.0" k2="2.150" idivf2="1" periodicity2="2" phase2="0.0" phase3="0.0" k3="1.200" idivf3="1" periodicity3="1"/>
+    <Proper smirks="[#6X4:1]-[#7X4,#7X3:2]-[#7X4,#7X3:3]-[#6X4:4]" id="t125" idivf1="1" k1="0.375" periodicity1="3" phase1="0.0" k2="2.125" idivf2="1" periodicity2="2" phase2="0.0" phase3="0.0" k3="1.500" idivf3="1" periodicity3="1"/>
     <Proper smirks="[*:1]-[#7X4,#7X3:2]-[#7X3$(*~[#6X3,#6X2]):3]~[*:4]" id="t126" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[*:1]-[#7X3$(*-[#6X3,#6X2]):2]-[#7X3$(*-[#6X3,#6X2]):3]-[*:4]" id="t127" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[*:1]-[#7X3$(*-[#6X3,#6X2])r5:2]-@[#7X3$(*-[#6X3,#6X2])r5:3]~[*:4]" id="t128" idivf1="1" k1="3.600" periodicity1="2" phase1="180.0"/>
@@ -276,24 +276,24 @@
     <Proper smirks="[*:1]~[#16X4,#16X3+0:2]-[#7:3]~[*:4]" id="t135" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#1:4]" id="t136" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[#6X3:1]-[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#1:4]" id="t137" idivf1="1" k1="0.500" periodicity1="3" phase1="0.0"/>
-    <Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#6X4:4]" id="t138" idivf1="1" k1="2.500" periodicity1="1" phase1="0.0" k2="0.750" phase2="0.0" idivf2="1" periodicity2="3"/>
-    <Proper smirks="[#6X3:1]-[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#6X4:4]" id="t139" idivf1="1" k1="0.500" periodicity1="3" phase1="0.0" k2="1.750" phase2="0.0" idivf2="1" periodicity2="2" phase3="0.0" idivf3="1" k3="1.500" periodicity3="1"/>
-    <Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#1:4]" id="t140" idivf1="1" k1="1.000" periodicity1="1" phase1="180.0" k2="0.250" phase2="0.0" idivf2="1" periodicity2="3"/>
-    <Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#6X4:4]" id="t141" idivf1="1" k1="0.200" periodicity1="3" phase1="0.0" k2="0.300" phase2="180.0" idivf2="1" periodicity2="2" phase3="0.0" idivf3="1" k3="0.700" periodicity3="1"/>
-    <Proper smirks="[#6X3:1]-[#16X4,#16X3+0:2]-[#7X3:3]-[#6X3:4]" id="t142" idivf1="1" k1="0.500" periodicity1="3" phase1="0.0" k2="1.750" phase2="0.0" idivf2="1" periodicity2="2" phase3="0.0" idivf3="1" k3="1.500" periodicity3="1"/>
-    <Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#7X3:3]-[#6X3:4]" id="t143" idivf1="1" k1="0.500" periodicity1="3" phase1="90.0" k2="1.375" phase2="0.0" idivf2="1" periodicity2="2"/>
+    <Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#6X4:4]" id="t138" idivf1="1" k1="2.500" periodicity1="1" phase1="0.0" k2="0.750" idivf2="1" periodicity2="3" phase2="0.0"/>
+    <Proper smirks="[#6X3:1]-[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#6X4:4]" id="t139" idivf1="1" k1="0.500" periodicity1="3" phase1="0.0" k2="1.750" idivf2="1" periodicity2="2" phase2="0.0" phase3="0.0" k3="1.500" idivf3="1" periodicity3="1"/>
+    <Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#1:4]" id="t140" idivf1="1" k1="1.000" periodicity1="1" phase1="180.0" k2="0.250" idivf2="1" periodicity2="3" phase2="0.0"/>
+    <Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X4,#7X3:3]-[#6X4:4]" id="t141" idivf1="1" k1="0.200" periodicity1="3" phase1="0.0" k2="0.300" idivf2="1" periodicity2="2" phase2="180.0" phase3="0.0" k3="0.700" idivf3="1" periodicity3="1"/>
+    <Proper smirks="[#6X3:1]-[#16X4,#16X3+0:2]-[#7X3:3]-[#6X3:4]" id="t142" idivf1="1" k1="0.500" periodicity1="3" phase1="0.0" k2="1.750" idivf2="1" periodicity2="2" phase2="0.0" phase3="0.0" k3="1.500" idivf3="1" periodicity3="1"/>
+    <Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#7X3:3]-[#6X3:4]" id="t143" idivf1="1" k1="0.500" periodicity1="3" phase1="90.0" k2="1.375" idivf2="1" periodicity2="2" phase2="0.0"/>
     <Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X3:3]-[#6X3:4]" id="t144" idivf1="1" k1="0.750" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X3:3]-[#7X2:4]" id="t145" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[*:1]~[#16X4,#16X3+0:2]=,:[#7X2:3]-,:[*:4]" id="t146" idivf1="1" k1="0." periodicity1="1" phase1="0.0"/>
-    <Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#7X2:3]~[#6X3:4]" id="t147" idivf1="1" k1="0.040" periodicity1="6" phase1="0.0" k2="0.407" phase2="0.0" idivf2="1" periodicity2="5" phase3="0.0" idivf3="1" k3="0.013" periodicity3="4" periodicity4="3" k4="0.018" phase4="0.0" idivf4="1" periodicity5="2" idivf5="1" k5="1.329" phase5="180.0" idivf6="1" k6="0.927" periodicity6="1" phase6="0.0"/>
-    <Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X2:3]~[#6X3:4]" id="t148" idivf1="1" k1="0.071" periodicity1="6" phase1="0.0" k2="0.697" phase2="0.0" idivf2="1" periodicity2="5" phase3="180.0" idivf3="1" k3="0.208" periodicity3="4" periodicity4="2" k4="3.931" phase4="180.0" idivf4="1" periodicity5="3" idivf5="1" k5="1.940" phase5="180.0" idivf6="1" k6="2.448" periodicity6="1" phase6="0.0"/>
+    <Proper smirks="[#6X4:1]-[#16X4,#16X3+0:2]-[#7X2:3]~[#6X3:4]" id="t147" idivf1="1" k1="0.040" periodicity1="6" phase1="0.0" k2="0.407" idivf2="1" periodicity2="5" phase2="0.0" phase3="0.0" k3="0.013" idivf3="1" periodicity3="4" idivf4="1" phase4="0.0" periodicity4="3" k4="0.018" periodicity5="2" idivf5="1" phase5="180.0" k5="1.329" phase6="0.0" idivf6="1" periodicity6="1" k6="0.927"/>
+    <Proper smirks="[#8X1:1]~[#16X4,#16X3+0:2]-[#7X2:3]~[#6X3:4]" id="t148" idivf1="1" k1="0.071" periodicity1="6" phase1="0.0" k2="0.697" idivf2="1" periodicity2="5" phase2="0.0" phase3="180.0" k3="0.208" idivf3="1" periodicity3="4" idivf4="1" phase4="180.0" periodicity4="2" k4="3.931" periodicity5="3" idivf5="1" phase5="180.0" k5="1.940" phase6="0.0" idivf6="1" periodicity6="1" k6="2.448"/>
     <Proper smirks="[*:1]~[#16X4,#16X3+0:2]-[#8X2:3]-[*:4]" id="t149" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
-    <Proper smirks="[*:1]-[#16X2,#16X3+1:2]-[#16X2,#16X3+1:3]-[*:4]" id="t150" idivf1="1" k1="3.500" periodicity1="2" phase1="0.0" k2="0.600" phase2="0.0" idivf2="1" periodicity2="3"/>
+    <Proper smirks="[*:1]-[#16X2,#16X3+1:2]-[#16X2,#16X3+1:3]-[*:4]" id="t150" idivf1="1" k1="3.500" periodicity1="2" phase1="0.0" k2="0.600" idivf2="1" periodicity2="3" phase2="0.0"/>
     <Proper smirks="[*:1]-[#8X2:2]-[#15:3]~[*:4]" id="t151" idivf1="1" k1="0.750" periodicity1="3" phase1="0.0"/>
-    <Proper smirks="[#8X2:1]-[#15:2]-[#8X2:3]-[#6X4:4]" id="t152" idivf1="1" k1="0.250" periodicity1="3" phase1="0.0" k2="1.200" phase2="0.0" idivf2="1" periodicity2="2"/>
+    <Proper smirks="[#8X2:1]-[#15:2]-[#8X2:3]-[#6X4:4]" id="t152" idivf1="1" k1="0.250" periodicity1="3" phase1="0.0" k2="1.200" idivf2="1" periodicity2="2" phase2="0.0"/>
     <Proper smirks="[*:1]~[#7X3:2]-[#15:3]~[*:4]" id="t153" idivf1="1" k1="2.5" periodicity1="2" phase1="180.000"/>
     <Proper smirks="[*:1]~[#7X4:2]-[#15:3]~[*:4]" id="t154" idivf1="1" k1="0.1" periodicity1="3" phase1="0.000"/>
-    <Proper smirks="[*:1]-[#7:2]-[#15:3]=[*:4]" id="t155" idivf1="1" k1="3.000" periodicity1="2" phase1="180.0" k2="2.300" phase2="0.0" idivf2="1" periodicity2="3"/>
+    <Proper smirks="[*:1]-[#7:2]-[#15:3]=[*:4]" id="t155" idivf1="1" k1="3.000" periodicity1="2" phase1="180.0" k2="2.300" idivf2="1" periodicity2="3" phase2="0.0"/>
     <Proper smirks="[#6X3:1]-[#7:2]-[#15:3]=[*:4]" id="t156" idivf1="1" k1="2.300" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[*:1]-[*:2]#[*:3]-[*:4]" id="t157" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
     <Proper smirks="[*:1]~[*:2]-[*:3]#[*:4]" id="t158" idivf1="1" k1="0.000" periodicity1="1" phase1="0.0"/>
@@ -328,5 +328,14 @@
     <Atom smirks="[#17:1]" epsilon="0.265" id="n25" rmin_half="1.948"/>
     <Atom smirks="[#35:1]" epsilon="0.320" id="n26" rmin_half="2.22"/>
     <Atom smirks="[#53:1]" epsilon="0.40" id="n27" rmin_half="2.35"/>
+    <Atom smirks="[#3+1:1]" epsilon="0.0279896" id="n28" rmin_half="1.025"/>
+    <Atom smirks="[#11+1:1]" epsilon="0.0874393" id="n29" rmin_half="1.369"/>
+    <Atom smirks="[#19+1:1]" epsilon="0.1936829" id="n30" rmin_half="1.705"/>
+    <Atom smirks="[#37+1:1]" epsilon="0.3278219" id="n31" rmin_half="1.813"/>
+    <Atom smirks="[#55+1:1]" epsilon="0.4065394" id="n32" rmin_half="1.976"/>
+    <Atom smirks="[#9X0-1:1]" epsilon="0.0033640" id="n33" rmin_half="2.303"/>
+    <Atom smirks="[#17X0-1:1]" epsilon="0.0355910" id="n34" rmin_half="2.513"/>
+    <Atom smirks="[#35X0-1:1]" epsilon="0.0586554" id="n35" rmin_half="2.608"/>
+    <Atom smirks="[#53X0-1:1]" epsilon="0.0536816" id="n36" rmin_half="2.860"/>
   </NonbondedForce>
 </SMIRNOFF>


### PR DESCRIPTION
As per https://github.com/open-forcefield-group/openforcefield/pull/53, update to include default Joung/Cheatham monovalent ion parameters for TIP3P. If different parameters are desired (e.g. for a different water model) these should be loaded after the ones in this forcefield.

@bannanc - please do quick check and merge when ready. :) 